### PR TITLE
Feature: Update Models

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           echo "GH_REPO: $GH_REPO"
           echo "GH_ORG: $GH_ORG"
       - name: Test Row/Column DBT BQ Checks
-        uses: org-not-included/dbt_table_diff@v1
+        uses: org-not-included/dbt_table_diff@v2
         with:
           GCP_TOKEN: $GCP_TOKEN
           GH_TOKEN: $GH_TOKEN
@@ -34,3 +34,4 @@ jobs:
           fallback_prefix: 'fb_'
           project_id: 'ultimate-bit-359101'
           DBT_PROFILE_FILE: "profile.yml"
+          custom_checks_path: "sql_checks"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           echo "GH_REPO: $GH_REPO"
           echo "GH_ORG: $GH_ORG"
       - name: Test Row/Column DBT BQ Checks
-        uses: org-not-included/dbt_table_diff@v2.2.1
+        uses: org-not-included/dbt_table_diff@v2.2.2
         with:
           GCP_TOKEN: $GCP_TOKEN
           GH_TOKEN: $GH_TOKEN

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           echo "GH_REPO: $GH_REPO"
           echo "GH_ORG: $GH_ORG"
       - name: Test Row/Column DBT BQ Checks
-        uses: org-not-included/dbt_table_diff@v2
+        uses: org-not-included/dbt_table_diff@v2.2.1
         with:
           GCP_TOKEN: $GCP_TOKEN
           GH_TOKEN: $GH_TOKEN

--- a/models/example/my_first_dbt_model.sql
+++ b/models/example/my_first_dbt_model.sql
@@ -11,9 +11,11 @@
 
 with source_data as (
 
-    select 1 as id
+    select 7 as new_id
     union all
-    select null as id
+    select 13 as new_id
+    union all
+    select 27 as new_id
 
 )
 

--- a/models/example/my_second_dbt_model.sql
+++ b/models/example/my_second_dbt_model.sql
@@ -1,6 +1,6 @@
 
 -- Use the `ref` function to select from other models
 
-select *
+select new_id + 1 as newest_id
 from {{ ref('my_first_dbt_model') }}
 where new_id = 1

--- a/models/example/my_second_dbt_model.sql
+++ b/models/example/my_second_dbt_model.sql
@@ -3,4 +3,4 @@
 
 select *
 from {{ ref('my_first_dbt_model') }}
-where id = 1
+where new_id = 1

--- a/sql_checks/custom_check.sql
+++ b/sql_checks/custom_check.sql
@@ -1,0 +1,11 @@
+with source_info as (
+    SELECT * FROM `{{ dataset }}.{{ schema }}.__TABLES__` where table_id = '{{table}}'
+),
+target_info as (
+    SELECT * FROM `{{ dataset }}.{{ compare_schema }}.__TABLES__` where table_id = '{{table}}'
+)
+SELECT
+    source_info.size_bytes as source_size,
+    target_info.size_bytes as target_size,
+    source_info.size_bytes - target_info.size_bytes as diff
+from source_info, target_info


### PR DESCRIPTION
**Overview:**
This PR serves as Proof-of-concept for how to use [org-not-included/dbt_table_diff@v1](https://github.com/marketplace/actions/run-checks-against-dbt-models).

`dbt_table_diff` will add a comment on Open PRs with Row and Column comparisons between your dev and prod environments.

In `.github/workflows/main.yml` there is an example Github Workflow, which calls `dbt_table_diff` and adds a comment on this PR.

**Changes:**
- changed `id` to `new_id` in `models/example/`
- added more rows to `my_first_dbt_model` (2->3)
- made it so `my_second_dbt_model` should have less rows (1->0)